### PR TITLE
Add apu5 target and release process cleanup

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -73,16 +73,28 @@ For APU3 target in *legacy* build this command should be used:
 ./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build apu3
 ```
 
+For APU5 target in *legacy* build:
+```
+./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build apu5
+```
+
 There are also additional commands like:
 ```
-# distclean && menuconfig
+# distclean
 ./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build-ml distclean
+# or for legacy
+./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build distclean
 
-#rm -rf .config* && menuconfig
+# rm -rf .config*
 ./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build-ml cfgclean
+# or for legacy
+./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build cfgclean
 
-#custom make parameters
+# custom make parameters
 ./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build-ml custom <param>
+# or for legacy
+./apu2/apu2-documentation/scripts/apu2_fw_rel.sh build custom <param>
+
 ```
 
 After successful build, you can flash target device.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -107,16 +107,14 @@ device and destination OS
 or other distro that have working `flashrom` available in `PATH`. Without keys
 added you will see question about password couple times during flashing.
 
-For legacy:
-
 ```
 ./apu2/apu2-documentation/scripts/apu2_fw_rel.sh flash <user>@<ip_address>
 ```
 
-For mainline:
+For forcing the flash (board identification mismatch):
 
 ```
-./apu2/apu2-documentation/scripts/apu2_fw_rel.sh flash-ml <user>@<ip_address>
+./apu2/apu2-documentation/scripts/apu2_fw_rel.sh flash-force <user>@<ip_address>
 ```
 
 Best way is to use `root` as `<user>` because it can have no problem with low
@@ -138,8 +136,8 @@ Since it use `git` commands to create build timestamp.
 #### flashing doesn't work
 
 ```
-[21:51:53] pietrushnic:apu2_fw_rel $ ../apu2-documentation/scripts/apu2_fw_rel.sh flash-ml pcengines@192.168.0.103
-flash-ml pcengines@192.168.0.103
+[21:51:53] pietrushnic:apu2_fw_rel $ ../apu2-documentation/scripts/apu2_fw_rel.sh flash pcengines@192.168.0.103
+flash pcengines@192.168.0.103
 The authenticity of host '192.168.0.103 (192.168.0.103)' can't be established.
 (...)
 Are you sure you want to continue connecting (yes/no)? yes

--- a/scripts/apu2_fw_rel.sh
+++ b/scripts/apu2_fw_rel.sh
@@ -2,26 +2,9 @@
 
 echo $*
 
-if [ "$1" == "build-ml" ] || [ "$1" == "flash-ml" ] || [ "$1" == "custom-ml" ]; then
-  if [ ! -d ${PWD}/apu2/coreboot ];then
-    git clone https://review.coreboot.org/coreboot.git ${PWD}/apu2/coreboot
-    cd ${PWD}/apu2/coreboot
-    git submodule update --init --checkout
-    git remote add pcengines http://github.com/pcengines/coreboot.git
-    git fetch pcengines
-    git checkout -b coreboot-4.5.x pcengines/coreboot-4.5.x
-    cd ../..
-  fi
-  docker run --rm -it \
-  -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK  \
+ssh-add && \
+docker run --rm -it \
+  -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK  \
+  -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \
   -v ${PWD}:/release \
   pcengines/apu2 /bin/bash -c "/release/apu2/apu2-documentation/scripts/build_release_img.sh $*"
-else
-  if [ ! -d ${PWD}/apu2/coreboot ];then
-    git clone git@github.com:pcengines/coreboot.git ${PWD}/apu2/coreboot
-  fi
-  docker run --rm -it \
-  -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK  \
-  -v ${PWD}:/release \
-  pcengines/apu2 /bin/bash -c "/release/apu2/apu2-documentation/scripts/build_release_img.sh $*"
-fi

--- a/scripts/build_release_img.sh
+++ b/scripts/build_release_img.sh
@@ -79,22 +79,11 @@ if [ "$1" == "flash" ] || [ "$1" == "flash-force" ]; then
   if [ "$1" == "flash-force" ]; then
     ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal:boardmismatch=force && reboot"
   else
-    ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal&& reboot"
+    ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal && reboot"
   fi
 
 elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
   cd $CB_PATH
-
-  if [ "$1" == "build" -a ! -f .config ]; then
-    if [ "$2" == "apu3" ]; then
-      cp configs/pcengines_apu3.config .config
-    elif [ "$2" == "apu5" ]; then
-      cp configs/pcengines_apu5.config .config
-    else
-      cp configs/pcengines_apu2.config .config
-    fi
-    make oldconfig
-  fi
 
   if [ "$2" == "distclean" ]; then
     make distclean
@@ -109,6 +98,17 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
   elif [ "$2" == "custom" ]; then
     make $3
     exit
+  fi
+
+  if [ "$1" == "build" -a ! -f .config ]; then
+    if [ "$2" == "apu3" ]; then
+      cp configs/pcengines_apu3.config .config
+    elif [ "$2" == "apu5" ]; then
+      cp configs/pcengines_apu5.config .config
+    else
+      cp configs/pcengines_apu2.config .config
+    fi
+    make oldconfig
   fi
 
   build_coreboot

--- a/scripts/build_release_img.sh
+++ b/scripts/build_release_img.sh
@@ -68,17 +68,20 @@ pack_release () {
 }
 
 
-if [ "$1" == "flash" ] || [ "$1" == "flash-ml" ]; then
+if [ "$1" == "flash" ] || [ "$1" == "flash-force" ]; then
   APU2_LOGIN=$2
-  if [ "$1" == "flash" ]; then
-    ssh $APU2_LOGIN remountrw
-  fi
   if [ ! -f $CB_PATH/build/coreboot.rom ]; then
       echo "ERROR: $CB_PATH/build/coreboot.rom doesn't exist. Please build coreboot first"
       exit
   fi
   scp $CB_PATH/build/coreboot.rom $APU2_LOGIN:/tmp
-  ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal && reboot"
+
+  if [ "$1" == "flash-force" ]; then
+    ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal:boardmismatch=force && reboot"
+  else
+    ssh $APU2_LOGIN "flashrom -w /tmp/coreboot.rom -p internal&& reboot"
+  fi
+
 elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
   cd $CB_PATH
 

--- a/scripts/build_release_img.sh
+++ b/scripts/build_release_img.sh
@@ -85,6 +85,8 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
   if [ "$1" == "build" -a ! -f .config ]; then
     if [ "$2" == "apu3" ]; then
       cp configs/pcengines_apu3.config .config
+    elif [ "$2" == "apu5" ]; then
+      cp configs/pcengines_apu5.config .config
     else
       cp configs/pcengines_apu2.config .config
     fi
@@ -93,22 +95,11 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
 
   if [ "$2" == "distclean" ]; then
     make distclean
-    if [ "$1" == "build" ];then
-      cp configs/pcengines_apu2.config .config
-      make oldconfig
-    else
-      make menuconfig
-    fi
   elif [ "$2" == "menuconfig" ]; then
     make menuconfig
   elif [ "$2" == "cfgclean" ]; then
     make clean
     rm -rf .config .config.old
-    if [ "$1" == "build" ];then
-      cp configs/pcengines_apu2.config .config
-      make oldconfig
-    fi
-    make menuconfig
   elif [ "$2" == "custom" ]; then
     make $3
   fi

--- a/scripts/build_release_img.sh
+++ b/scripts/build_release_img.sh
@@ -95,13 +95,17 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
 
   if [ "$2" == "distclean" ]; then
     make distclean
+    exit
   elif [ "$2" == "menuconfig" ]; then
     make menuconfig
+    exit
   elif [ "$2" == "cfgclean" ]; then
     make clean
     rm -rf .config .config.old
+    exit
   elif [ "$2" == "custom" ]; then
     make $3
+    exit
   fi
 
   build_coreboot
@@ -115,9 +119,6 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
 elif [ "$1" == "build-coreboot" ]; then
   build_coreboot
   create_image
-elif [ "$1" == "custom-ml" ]; then
-  cd $CB_PATH
-  make $2
 else
   echo "ERROR: unknown command $1"
 fi

--- a/scripts/build_release_img.sh
+++ b/scripts/build_release_img.sh
@@ -100,15 +100,19 @@ elif [ "$1" == "build" ] || [ "$1" == "build-ml" ]; then
     exit
   fi
 
-  if [ "$1" == "build" -a ! -f .config ]; then
-    if [ "$2" == "apu3" ]; then
-      cp configs/pcengines_apu3.config .config
-    elif [ "$2" == "apu5" ]; then
-      cp configs/pcengines_apu5.config .config
-    else
-      cp configs/pcengines_apu2.config .config
+  if [ ! -f .config ]; then
+    if [ "$1" == "build" ]; then
+      if [ "$2" == "apu3" ]; then
+        cp configs/pcengines_apu3.config .config
+      elif [ "$2" == "apu5" ]; then
+        cp configs/pcengines_apu5.config .config
+      else
+        cp configs/pcengines_apu2.config .config
+      fi
+      make oldconfig
+    elif [ "$1" == "build-ml" ]; then
+      make menuconfig
     fi
-    make oldconfig
   fi
 
   build_coreboot


### PR DESCRIPTION
* added build for `apu5` target
* removed starting build after `distclean`, `cfgclean`, `custom`, `menuconfig` subcommands
* removed `custom-ml` command (redundant with `build-ml custom`)
* removed ml codepath from `apu2_fw_rel.sh` (not necessary, since we are initializing workdir with repo)
* removed `flash-ml` command (redundant), added `flash-force` command