### PR TITLE
RFC: README.md: maintainer process initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ We are in favor of [Test Driven Bug Fixing (TDBF)](https://geeknarrator.com/2018
 
 1. Create automated test that validate feature or reproduce bug - test fails at
    this point
-2. Push `coreboot's master branch` to `master`
-3. Update `develop` by `master`
-4. Checkout `feature_branch` from `develop`
+2. Pull `coreboot's master branch` to `master`
+3. Merge `master` to `develop`
+4. Create new branch `feature_branch` from `develop`
 5. Commit changes to `feature_branch`
 6. Run regression tests and fix bugs - test written in point 1 should pass at
    this point

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Branch description
 
 # Steps for new release
 
-1. Create new branch `rel_x.y.z`, where:
+1. Checkout new branch `rel_x.y.z` from recent commit on `release`, where:
     * `x` is coreboot major version
     * `y` is coreboot minor version
     * `z` is PC Engines firmware fork patch number

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We are in favor of [Test Driven Bug Fixing (TDBF)](https://geeknarrator.com/2018
 1. Checkout new branch `rel_x.y.z` from recent commit on `release`, where:
     * `x` is coreboot major version
     * `y` is coreboot minor version
-    * `z` is PC Engines firmware fork patch number
+    * `z` is PC Engines firmware fork patch number counted from `0`
 2. Merge current `develop` to `rel_x.y.z`
 3. End of month we close merge window
 4. Perform automated regression testing on `rel_x.y.z` including all new tests

--- a/README.md
+++ b/README.md
@@ -41,6 +41,21 @@ Branch description
 * `develop` - where current development takes place periodically synced with
   coreboot master
 * `rel_x.y.z` - release branches described below
+* `feature_branch` - sample feature branch name for workflow explanation needs
+
+# Feature/bug fix development
+
+We are in favor of [Test Driven Bug Fixing (TDBF)](https://geeknarrator.com/2018/01/28/test-driven-bug-fixing-guidelines/).
+
+1. Create automated test that validate feature or reproduce bug - test fails at
+   this point
+2. Push `coreboot's master branch` to `master`
+3. Update `develop` by `master`
+4. Checkout `feature_branch` from `develop`
+5. Commit changes to `feature_branch`
+6. Run regression tests and fix bugs - test written in point 1 should pass at
+   this point
+7. Submit PR to `develop`
 
 # Steps for new release
 
@@ -48,23 +63,14 @@ Branch description
     * `x` is coreboot major version
     * `y` is coreboot minor version
     * `z` is PC Engines firmware fork patch number
-2. Create PR for all required changes for version `rel_x.y.z`
-3. When all changes pushed we closing merge window and start testing - this is
-   typically first week of each month
-4. Perform automated regression testing on `rel_x.y.z`
+2. Merge current `develop` to `rel_x.y.z`
+3. End of month we close merge window
+4. Perform automated regression testing on `rel_x.y.z` including all new tests
 5. Fix all required issues and repeat point 4 until fixed - this doesn't mean
    all tests pass, this mean that approved set passed
 6. If results are accepted merge it to `release` branch
 7. Add tag, which should trigger CI and publish binaries
 8. Merge release branch to develop
-
-# Feature/bug fix development
-
-1. Update `develop` by margining coreboot's master
-2. Checkout feature branch from `develop`
-3. Commit changes to feature branch
-4. Run regression tests
-5. Setup PR to `develop`
 
 Other resources
 ----------------

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Also please take a look at changelogs:
 * [v4.0.x changelog](https://github.com/pcengines/release_manifests/blob/coreboot-4.0.x/CHANGELOG.md)
 
 
-
-
 Building firmware using PC Engines firmware builder
 ---------------------------------------------------
 
@@ -35,6 +33,38 @@ and usage details please visit: https://github.com/pcengines/pce-fw-builder
 For releases older than v4.0.17 and v4.6.9 use the procedure described in this
 [document](docs/release_process.md)
 
+Branch description
+------------------
+
+* `master` - keeps track of [coreboot's master branch](https://review.coreboot.org/cgit/coreboot.git/log/)
+* `release` - where all releases are merged
+* `develop` - where current development takes place periodically synced with
+  coreboot master
+* `rel_x.y.z` - release branches described below
+
+# Steps for new release
+
+1. Create new branch `rel_x.y.z`, where:
+    * `x` is coreboot major version
+    * `y` is coreboot minor version
+    * `z` is PC Engines firmware fork patch number
+2. Create PR for all required changes for version `rel_x.y.z`
+3. When all changes pushed we closing merge window and start testing - this is
+   typically first week of each month
+4. Perform automated regression testing on `rel_x.y.z`
+5. Fix all required issues and repeat point 4 until fixed - this doesn't mean
+   all tests pass, this mean that approved set passed
+6. If results are accepted merge it to `release` branch
+7. Add tag, which should trigger CI and publish binaries
+8. Merge release branch to develop
+
+# Feature/bug fix development
+
+1. Update `develop` by margining coreboot's master
+2. Checkout feature branch from `develop`
+3. Commit changes to feature branch
+4. Run regression tests
+5. Setup PR to `develop`
 
 Other resources
 ----------------


### PR DESCRIPTION
This is a proposal of a new maintainer process as tracking coreboot releases doesn't make much sense since those are an arbitrary point in time.

Signed-off-by: Piotr Król <piotr.krol@3mdeb.com>