### PR TITLE
Add APU firmware updater script for OPNsense

### DIFF
--- a/docs/firmware_flashing.md
+++ b/docs/firmware_flashing.md
@@ -131,3 +131,15 @@ grub-mkconfig -o /boot/grub/grub.cfg
 ```
 
 Finally reboot
+
+APU firmware updater for OPNsense
+----------------
+
+You can use a script to update the firmware on an OPNsense firewall.
+
+* Login via SSH to your OPNsense firewall.
+* Copy the script [apu_fw_updater_opnsense.sh](https://github.com/pcengines/apu2-documentation/tree/master/scripts/apu_fw_updater_opnsense.sh) where you want it.
+* Make the script executable using `chmod +x apu_fw_updater_opnsense.sh`.
+* Set the correct type, e.g. `TYPE="apu2"`.
+* Set the desired version, e.g. `VERSION="4.12.0.4"`.
+* Execute the script `./apu_fw_updater_opnsense.sh`.

--- a/scripts/apu_fw_updater_opnsense.sh
+++ b/scripts/apu_fw_updater_opnsense.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+###
+# APU firmware updater for OPNsense.
+#
+# Requires:
+# - flashrom (pkg install -y flashrom)
+#
+# Installation:
+# - Login via SSH to the firewall
+# - Create the script where you want it
+# - Make it executable (chmod +x apu_fw_updater_opnsense.sh)
+###
+
+# Params
+
+# Type of APU (apu1, apu2, apu3, apu4, apu5)
+TYPE="apu2"
+
+# Version of firmware
+VERSION="4.12.0.4"
+
+# Do not edit after this line
+SRC="https://3mdeb.com/open-source-firmware/pcengines/${TYPE}/"
+PREFIX="${TYPE}_v${VERSION}"
+FILE="${PREFIX}.rom"
+CHECKSUM="${PREFIX}.SHA256"
+NUMBER="$(echo ${TYPE} | tr -dc '0-9')"
+
+echo
+echo "+-----------------------------------+"
+echo "| APU firmware updater for OPNsense |"
+echo "+-----------------------------------+"
+
+cd "/tmp"
+
+log () {
+  echo
+  echo "`date +"%Y-%m-%d %T"` | ${1}"
+}
+
+log_sub () {
+  echo "                    | ${1}"
+}
+
+params () {
+  log "Params"
+  log_sub "Type: ${TYPE}"
+  log_sub "Version: ${VERSION}"
+}
+
+verify () {
+  if [ $? != 0 ]; then
+    log_sub "... failed."
+
+    echo
+    exit 1
+  fi
+}
+
+download () {
+  log "Downloading files ..."
+
+  log_sub "- ${FILE}"
+  curl -sS "${SRC}${FILE}" -o "${FILE}"
+
+  log_sub "- ${CHECKSUM}"
+  curl -sS "${SRC}${CHECKSUM}" -o "${CHECKSUM}"
+
+  verify
+
+  log_sub "... done."
+}
+
+checksum () {
+  log "Verify checksum ..."
+
+  shasum -c "${CHECKSUM}"
+
+  verify
+
+  log_sub "... done."
+}
+
+flash () {
+  log "Flash firmware ..."
+
+  if [ "${NUMBER}" -gt 1 ]; then
+    # APU2/3/4/5
+    flashrom -w "${FILE}" -p internal
+  else
+    # APU1
+    flashrom -w "${FILE}" -p internal -c "MX25L1605A/MX25L1606E/MX25L1608E"
+  fi
+
+  log_sub "... done."
+}
+
+cleanup () {
+  log "Cleanup ..."
+
+  log_sub "- ${FILE}"
+  rm "${FILE}"
+
+  log_sub "- ${CHECKSUM}"
+  rm "${CHECKSUM}"
+
+  log_sub "... done."
+}
+
+reboot () {
+  log "Rebooting in 5s ..."
+
+  sleep 5
+
+  reboot
+}
+
+params
+
+download
+
+checksum
+
+flash
+
+cleanup
+
+#reboot
+
+echo
+exit 0


### PR DESCRIPTION
Adds an APU firmware updater script for [OPNsense](https://opnsense.org).

- Downloads the required files
- Verifies the checksum
- Flashes the firmware
- Removes the files

I decided against the use of script params, e.g. `./firmware-updater.sh apu2 4.12.0.4` because if you need to change it in the script prior to execute it, you are more aware of what you are doing :wink:

But if someone really wants this functionality you just have to replace in the script:

```sh
TYPE="apu2"
VERSION="4.12.0.4"
```

by

```sh
TYPE=${1}
VERSION=${2}
```