### PR TITLE
Add APU6 and fix shellcheck warnings

### DIFF
--- a/scripts/apu_fw_updater_opnsense.sh
+++ b/scripts/apu_fw_updater_opnsense.sh
@@ -13,11 +13,11 @@
 
 # Params
 
-# Type of APU (apu1, apu2, apu3, apu4, apu5)
+# Type of APU (apu1, apu2, apu3, apu4, apu5, apu6)
 TYPE="apu2"
 
 # Version of firmware
-VERSION="4.12.0.5"
+VERSION="4.15.0.3"
 
 # Do not edit after this line
 SRC="https://3mdeb.com/open-source-firmware/pcengines/${TYPE}/"
@@ -31,11 +31,11 @@ echo "+-----------------------------------+"
 echo "| APU firmware updater for OPNsense |"
 echo "+-----------------------------------+"
 
-cd "/tmp"
+cd "/tmp" || exit
 
 log () {
   echo
-  echo "`date +"%Y-%m-%d %T"` | ${1}"
+  echo "$(date +"%Y-%m-%d %T") | ${1}"
 }
 
 log_sub () {
@@ -85,7 +85,7 @@ flash () {
   log "Flash firmware ..."
 
   if [ "${NUMBER}" -gt 1 ]; then
-    # APU2/3/4/5
+    # APU2/3/4/5/6
     flashrom -w "${FILE}" -p internal
   else
     # APU1


### PR DESCRIPTION
### Adds **APU6**

```sh
+-----------------------------------+
| APU firmware updater for OPNsense |
+-----------------------------------+

2022-03-10 09:05:51 | Params
                    | Type: apu6
                    | Version: 4.15.0.3

2022-03-10 09:05:51 | Downloading files ...
                    | - apu6_v4.15.0.3.rom
                    | - apu6_v4.15.0.3.SHA256
                    | ... done.

2022-03-10 09:05:53 | Verify checksum ...
apu6_v4.15.0.3.rom: OK
                    | ... done.

2022-03-10 09:05:53 | Flash firmware ...
flashrom v1.2 on FreeBSD 13.0-STABLE (amd64)
flashrom is free software, get the source code at https://flashrom.org

Using clock_gettime for delay loops (clk_id: 4, resolution: 2ns).
coreboot table found at 0xcfeba000.
Found chipset "AMD FCH".
Enabling flash write... OK.
Found Winbond flash chip "W25Q64.V" (8192 kB, SPI) mapped at physical address 0x00000000ff800000.
Reading old flash chip contents... done.
Erasing and writing flash chip... Erase/write done.
Verifying flash... VERIFIED.
                    | ... done.

2022-03-10 09:06:20 | Cleanup ...
                    | - apu6_v4.15.0.3.rom
                    | - apu6_v4.15.0.3.SHA256
                    | ... done.

2022-03-10 09:06:20 | Rebooting in 5s ...
```

---

### Fixes some shellcheck warnings

![image](https://user-images.githubusercontent.com/18613935/157616567-243d45c3-4696-4f4a-ba4e-b8a2f9035f0d.png)

![image](https://user-images.githubusercontent.com/18613935/157616510-41fdd63b-cd42-43cd-9ba2-8184dad79e47.png)