### PR TITLE
Fix download URL (#323), specify chipname for APU2 and higher as well for recent flashrom versions

### DIFF
--- a/scripts/apu_fw_updater_opnsense.sh
+++ b/scripts/apu_fw_updater_opnsense.sh
@@ -20,7 +20,7 @@ TYPE="apu2"
 VERSION="4.15.0.3"
 
 # Do not edit after this line
-SRC="https://3mdeb.com/open-source-firmware/pcengines/${TYPE}/"
+SRC="https://dl.3mdeb.com/open-source-firmware/pcengines/${TYPE}/"
 PREFIX="${TYPE}_v${VERSION}"
 FILE="${PREFIX}.rom"
 CHECKSUM="${PREFIX}.SHA256"

--- a/scripts/apu_fw_updater_opnsense.sh
+++ b/scripts/apu_fw_updater_opnsense.sh
@@ -86,7 +86,7 @@ flash () {
 
   if [ "${NUMBER}" -gt 1 ]; then
     # APU2/3/4/5/6
-    flashrom -w "${FILE}" -p internal
+    flashrom -w "${FILE}" -p internal -c "W25Q64BV/W25Q64CV/W25Q64FV"
   else
     # APU1
     flashrom -w "${FILE}" -p internal -c "MX25L1605A/MX25L1606E/MX25L1608E"


### PR DESCRIPTION
Fixes https://github.com/pcengines/apu2-documentation/issues/323
Fixes "Multiple flash chip definitions" found with recent flashrom